### PR TITLE
Removed connect() on the socket.

### DIFF
--- a/check_openvpn
+++ b/check_openvpn
@@ -49,8 +49,7 @@ def checkserver(host,port,proto):
     ovpn_sock.settimeout(5)
 
     try:
-        ovpn_sock.connect((host, port))
-        ovpn_sock.sendto(byte_stream, (host, port))
+        ovpn_sock.sendto(byte_stream,(host,port))
         data, addr = ovpn_sock.recvfrom(1024) # buffer size is 1024 bytes
         reply = binascii.hexlify(data)
         if proto:


### PR DESCRIPTION
According to https://docs.python.org/2/library/socket.html#socket.socket.sendto the sendto() should only be used when not connected. Removed connect since sendto() connect to the specified address. 

This patch fixes the problem ( [Errno 56] Socket is already connected ) on OS X. 
